### PR TITLE
Use xwinwrap without WID

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Example
 
 ### Changes
 
-* Added ability to make undecorated window
-* Changed how desktop window is found
-* Refactored window hints
+* (ujjwal96) Added ability to make undecorated window
+* (ujjwal96) Changed how desktop window is found
+* (ujjwal96) Refactored window hints
+* (Azorlogh) Added the -fa flag to seek and attach the child window
 
 ----
 Original source - https://launchpad.net/xwinwrap


### PR DESCRIPTION
Bring in the changes from Azorlogh's fork that force a window to be a child of xwinwrap.